### PR TITLE
Allow memory configuration to propagate through.

### DIFF
--- a/lib/java_buildpack/framework/java_opts.rb
+++ b/lib/java_buildpack/framework/java_opts.rb
@@ -32,11 +32,12 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
-        parsed_java_opts.each do |option|
-          if memory_option? option
-            fail "Java option '#{option}' configures a memory region.  Use JRE configuration for this instead."
-          end
-        end
+        # Allow memory configuration to propagate through		
+        #parsed_java_opts.each do |option|
+        #  if memory_option? option
+        #    fail "Java option '#{option}' configures a memory region.  Use JRE configuration for this instead."
+        #  end
+        #end
       end
 
       # (see JavaBuildpack::Component::BaseComponent#release)


### PR DESCRIPTION
Without this change, you cannot set JAVA_OPTS and override memory settings per app.
